### PR TITLE
Fix for issue #7

### DIFF
--- a/src/Traits/Thumbnail.php
+++ b/src/Traits/Thumbnail.php
@@ -193,7 +193,11 @@ trait Thumbnail
         $thumbnails_property = [];
         $thumbnail_count = 0;
         foreach ($image_files as $image) {
-            $image_partition = explode('-', basename($image));
+			
+			if (strpos(basename($image),'-')===false)
+                continue;
+			
+			$image_partition = explode('-', basename($image));
             $parent_thumbnail_name = $image_partition[0].'-'.$image_partition[1];
             if ($parent_name == $parent_thumbnail_name) {
                 $thumbnail_count++;


### PR DESCRIPTION
Added check to see if image name is formatted correctly. Otherwise it'll skip this asset.